### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -34,7 +34,7 @@ Resources:
     Properties:
       CodeUri: ./src/handlers/slack-bot.js
       Handler: slack-bot.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 128
       Timeout: 60
       Description: A Lambda function that echoes back messages back to Slack.


### PR DESCRIPTION
CloudFormation templates in building-bots-on-aws have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.